### PR TITLE
Fix NPM errors and build dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@
 module.exports = function(grunt) {
 
   grunt.loadNpmTasks("grunt-contrib-jshint");
-  grunt.loadNpmTasks("grunt-mocha-test");
+  grunt.loadNpmTasks("grunt-mocha-cli");
 
     grunt.initConfig({
         jshint: {
@@ -11,7 +11,7 @@ module.exports = function(grunt) {
             },
             all: ["lib/**/*.js", "standard/**/*.js"]
         },
-        mochaTest: {
+        mochacli: {
             test: {
                 options: {
                     reporter: 'spec'
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
         }
     });
 
-  grunt.registerTask("test", ["jshint", "mochaTest"]);
+  grunt.registerTask("test", ["jshint", "mochacli"]);
   grunt.registerTask("default", ["test"]);
 
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "devDependencies": {
         "grunt": "~0.4.1",
         "grunt-contrib-jshint": "~0.4.3",
-        "grunt-mocha-cli": "1.x"
+        "grunt-mocha-cli": "~1.2.1"
     },
     "licenses": [
         {


### PR DESCRIPTION
Sorry for the mixed focus of the commits, but I ran into the second issue trying to fix the first.

---
- NPM has depreciated the plural repositories field, so I ran `npm init` and used the latest spec fixes
- `grunt-mocha-cli` changed it's task name (a breaking change in a feature release :frowning: ), so I fixed the Grunt task and pegged the version to reduce the likelihood of that happening again.
